### PR TITLE
Fixes stopsignal=CTRL_BREAK_EVENT crashes supervisor when run as a service #27

### DIFF
--- a/supervisor/services.py
+++ b/supervisor/services.py
@@ -294,7 +294,9 @@ def runner(argv):
         # any unhandled exceptions and print statements.
         print("supervisor service is starting...")
         print("(execute this script with '-h' or '--help' if that isn't what you want)")
-        if not sys.stdout.isatty():
+        if sys.stdout is not None and sys.stdout.isatty():
+            pass
+        else:
             # By default, the service does not start a console and this
             # causes side effects in sending signals to the subprocess.
             # Manually starts when an output terminal is not detected.


### PR DESCRIPTION

`sys.stdout` was None on my system and prevented the service from starting. This change calls `win32console.AllocConsole` if `sys.stdout` is None or not a tty.