### PR TITLE
Documentation updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,11 @@ Install as Windows service
 --------------------------
 To install supervisor as a windows service run the command
 
-`python -m supervisor.services install -c {system-path}\\supervisord.conf`
+``python -m supervisor.services install -c {system-path}\\supervisord.conf``
 
 Or install from the utility script ({PythonHome}\\Scripts directory must be in the system path)
 
-`supervisor_service.exe install -c {system-path}\\supervisord.conf`
+``supervisor_service.exe install -c {system-path}\\supervisord.conf``
 
 Supervisor for Unix-Like System
 -------------------------------
@@ -36,6 +36,8 @@ Documentation
 You can view the current Supervisor documentation online `in HTML format
 <http://supervisord.org/>`_ .  This is where you should go for detailed
 installation and configuration documentation.
+
+Windows specific documentation can be found `here <https://github.com/alexsilva/supervisor/blob/windows/docs/windows.rst>`_.
 
 Mailing list, Reporting Bugs, and Viewing the Source Repository
 ---------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ To install supervisor as a windows service run the command
 
 ``python -m supervisor.services install -c {system-path}\\supervisord.conf``
 
-Or install from the utility script ({PythonHome}\\Scripts directory must be in the system path)
+Or install from the utility script (``{PythonHome}\\Scripts`` directory must be in the system path)
 
 ``supervisor_service.exe install -c {system-path}\\supervisord.conf``
 

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -1,0 +1,26 @@
+Windows idiosyncrasies
+======================
+
+Stop signals
+------------
+Supervisor for windows supports the following values for `stopsignal`:
+
+* SIGTERM
+* CTRL_C_EVENT
+* CTRL_BREAK_EVENT
+
+These correspond to ``SIGTERM``, ``SIGINT`` and ``SIGBREAK`` being raised respectively.
+
+Note that when run as a Windows service, supervisor is not guaranteed to be able to raise ``SIGINT`` in a child process.
+The child process must call ``SetConsoleCtrlHandler(NULL, false)`` (see the `Windows API documentation <https://docs.microsoft.com/en-us/windows/console/setconsolectrlhandler>`_)  in order to be able to accept the interrupt. 
+If your child process is running a Python script, this can be achieved be calling:
+
+.. code-block:: python
+    
+    import win32api
+    win32api.SetConsoleCtrlHandler(None, False)
+    
+from within your code.
+
+This requirement is due to the way supervisor launches subprocesses (with the ``CREATE_NEW_PROCESS_GROUP`` creation flag).
+A thorough discussion of this limitation can be found on `Stack Overflow <https://stackoverflow.com/a/35792192>`_.


### PR DESCRIPTION
I've added a documentation page for detailing things that work differently on windows. I started by adding the information on stopsignals detailed in #27.

I also fixed some formatting issues in the main readme (additional backticks required for .rst format).

You can see the results [here](https://github.com/philipstarkey/supervisor/tree/feature/docupdate) and [here](https://github.com/philipstarkey/supervisor/blob/feature/docupdate/docs/windows.rst).