### PR TITLE
Added support for sending window events to managed processes.

### DIFF
--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -1,9 +1,9 @@
 Windows idiosyncrasies
 ======================
 
-Stop signals
+Standard stop signals
 ------------
-Supervisor for windows supports the following values for `stopsignal`:
+Supervisor for windows supports the following values for ``stopsignal``:
 
 * SIGTERM
 * CTRL_C_EVENT
@@ -24,3 +24,16 @@ from within your code.
 
 This requirement is due to the way supervisor launches subprocesses (with the ``CREATE_NEW_PROCESS_GROUP`` creation flag).
 A thorough discussion of this limitation can be found on `Stack Overflow <https://stackoverflow.com/a/35792192>`_.
+
+
+Window events
+-------------
+Supervisor for windows also supports sending Window events to graphical applications.
+These include events such as ``WM_CLOSE``.
+
+The ``stopsignal`` configuration option thus supports strings such as ``WM_CLOSE`` or negative integers that correspond to the negative of the window event.
+For example, ``WM_CLOSE`` event is documented as ``16`` (see `here <https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-close>`_), so ``stopsignal=-16`` is equivalent to ``stopsignal=WM_CLOSE. 
+This allows private window events (with values in the range documented `here <https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-user>`_) to also be sent should your application support them.
+Remember, ``stopsignal`` must be specified as the negative of the event id.
+
+Note: The use of the negative id number is so that supervisor can distinguish them from the standard signals documented above. The Windows event id number is converted to a positive integer just prior to sending it to your application.

--- a/supervisor/helpers.py
+++ b/supervisor/helpers.py
@@ -84,9 +84,9 @@ class Popen(subprocess.Popen):
         if window:
             status = win32api.PostMessage(window[0], sig, None, None)
             status = self.check_win32api_status(status)
-            return "win signal: %s (status %s)" % (proc_name, status)
         else:
-            return "Failed to find window to send signal to."
+            status = "failed to find window to send signal"
+        return "win signal: %s (status %s)" % (proc_name, status)
 
     def kill2(self, sig, as_group=False, proc_name=None):
         if as_group:

--- a/supervisor/helpers.py
+++ b/supervisor/helpers.py
@@ -12,7 +12,9 @@ import subprocess
 import sys
 import win32api
 from win32file import ReadFile, WriteFile
+import win32gui
 from win32pipe import PeekNamedPipe
+import win32process
 
 from supervisor.compat import as_string, as_bytes
 
@@ -47,20 +49,52 @@ class Popen(subprocess.Popen):
             msg = "exit status %s" % (self.returncode,)
         return msg
 
-    def send_os_signal(self, sig, proc_name):
-        """Send signal by GenerateConsoleCtrlEvent"""
-        status = ctypes.windll.kernel32.GenerateConsoleCtrlEvent(sig, self.pid)
+    def check_win32api_status(self, status):
         if status == 0:
             status = win32api.FormatMessage(win32api.GetLastError())
             status = as_string(status, errors='ignore')
             status = status.strip('\r\n')
+        return status
+
+    def send_os_signal(self, sig, proc_name):
+        """Send signal by GenerateConsoleCtrlEvent"""
+        status = ctypes.windll.kernel32.GenerateConsoleCtrlEvent(sig, self.pid)
+        status = self.check_win32api_status(status)
         return "signal: %s (status %s)" % (proc_name, status)
+
+    def send_win_signal(self, sig, proc_name):
+        window = []
+
+        # callback for handling window search
+        def check_window(hwnd, window):
+            _, pid = win32process.GetWindowThreadProcessId(hwnd)
+            if pid == self.pid:
+                window.append(hwnd)
+                return False
+            return True
+
+        # find window
+        try:
+            win32gui.EnumWindows(check_window, window)
+        except pywintypes.error:
+            # Exception is raised by terminating search early (if a window is found)
+            # Ignore it!
+            pass
+
+        if window:
+            status = win32api.PostMessage(window[0], sig, None, None)
+            status = self.check_win32api_status(status)
+            return "win signal: %s (status %s)" % (proc_name, status)
+        else:
+            return "Failed to find window to send signal to."
 
     def kill2(self, sig, as_group=False, proc_name=None):
         if as_group:
             return self.taskkill()
         elif sig in [signal.CTRL_BREAK_EVENT, signal.CTRL_C_EVENT]:
             return self.send_os_signal(sig, proc_name)
+        elif sig < 0:
+            return self.send_win_signal(-sig, proc_name)
         else:
             return self.send_signal(sig)
 


### PR DESCRIPTION

This resolves #26

The `stopsignal` config option now supports Windows window events such as `WM_CLOSE` (and other events prefixed with `WM_`). These can also be specified using the negative of the event integer (negative numbers used to distinguish them from standard signals without having to introduce complex code into supervisor). For example, `-16` corresponds to `WM_CLOSE`. This allows custom user events (see `WM_USER` win32 documentation)